### PR TITLE
Add default helm set of nodeSelector,affinity and tolerations

### DIFF
--- a/charts/dkim-manager/templates/deployment.yaml
+++ b/charts/dkim-manager/templates/deployment.yaml
@@ -85,3 +85,15 @@ spec:
       - name: {{ . }}
       {{- end }}
       {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/dkim-manager/templates/deployment.yaml
+++ b/charts/dkim-manager/templates/deployment.yaml
@@ -85,15 +85,15 @@ spec:
       - name: {{ . }}
       {{- end }}
       {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.controller.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with .Values.controller.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with .Values.controller.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
Currently not possible to set which node to run this on. This patch fixes that